### PR TITLE
chore: plublish to wire-maven

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,23 @@ ios() {
 
 ```
 4. The dependency will be exposed as `carthage.AFNetworking` by default.
+
+## Publishing to [wire-maven](https://github.com/wireapp/wire-maven)
+
+To publish the plugin for internal consumption (e.g. in [kalium](https://github.com/wireapp/wire-maven)),
+checkout [wire-maven](https://github.com/wireapp/wire-maven) side by side with this repository:
+
+```
+.
+├─ carthage-gradle-pluging/
+├─ wire-maven/
+```
+
+then:
+
+- create a new branch in wire-maven with pattern `chore/carthage-gradle-plugin/vX.Y.Z`
+- run the `publish` task in `carthage-gradle-plugin` to generate the plugin's `.jar`
+- commit with message following the pattern `chore: add carthage-gradle-plugin vX.Y.Z`
+- create a pull request in wire-maven 
+
+Once the resulting pull request is merged in wire-maven a new version will be avalable for consumption.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ gradlePlugin {
 object PluginCoordinates {
 
     const val GROUP = "com.wire"
-    const val ARTIFACT = "carthage-plugin"
+    const val ARTIFACT = "carthage-gradle-plugin"
     const val VERSION = "0.0.1"
 
     const val ID = "$GROUP.$ARTIFACT"
@@ -58,7 +58,7 @@ object PluginCoordinates {
 publishing {
     repositories {
         maven {
-            url = uri("../local-maven/")
+            url = uri("../wire-maven/releases")
         }
     }
 }


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

The publishing task is set to publish to `../local-maven` which is inconvenient given that we want to temporarily publish to `../wire-maven/releases` at [wire-maven](https://github.com/wireapp/wire-maven)

### Solutions

Change the publish uri to `../wire-maven/releases` and correct the artifact's name

----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
